### PR TITLE
Update server.go with missing /

### DIFF
--- a/server.go
+++ b/server.go
@@ -77,9 +77,9 @@ var (
 
 	KBS_AUTH_PATH = "/v1/backup/auth"
 
-	ATTACHMENT_KEY_DOWNLOAD_PATH = "attachments/%s"
-	ATTACHMENT_ID_DOWNLOAD_PATH  = "attachments/%d"
-	ATTACHMENT_UPLOAD_PATH       = "attachments/"
+	ATTACHMENT_KEY_DOWNLOAD_PATH = "/attachments/%s"
+	ATTACHMENT_ID_DOWNLOAD_PATH  = "/attachments/%d"
+	ATTACHMENT_UPLOAD_PATH       = "/attachments/"
 	AVATAR_UPLOAD_PATH           = ""
 
 	STICKER_MANIFEST_PATH = "/stickers/%s/manifest.proto"


### PR DESCRIPTION
Add missing / to server.go for attachments.  Without this, the URL for attachments is incorrect.