### PR TITLE
Fetch remote identityKey with UUID for fingerprint generation.

### DIFF
--- a/store.go
+++ b/store.go
@@ -264,12 +264,12 @@ func ContactIdentityKey(id string) ([]byte, error) {
 	return append([]byte{5}, b...), nil
 }
 
-func GetFingerprint(remoteIdentifier string) ([]string, []byte, error) {
+func GetFingerprint(remoteUUID string, remoteIdentifier string) ([]string, []byte, error) {
 
 	localIdentifier := config.ConfigFile.Tel
 	localIdentityKey := MyIdentityKey()
 
-	remoteIdentityKey, err := ContactIdentityKey(remoteIdentifier)
+	remoteIdentityKey, err := ContactIdentityKey(remoteUUID)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Corresponding to Pull Request https://github.com/nanu-c/axolotl/pull/642

Assuming that all Identity Keys can be referenced by UUID, I changed the code for fingerprint generation to use the UUID instead of the Tel.
This should fix [#548](https://github.com/nanu-c/axolotl/issues/548)