### PR TITLE
fixed Regex for Groupmessaging

### DIFF
--- a/cmd/textsecure/main.go
+++ b/cmd/textsecure/main.go
@@ -381,7 +381,7 @@ func RekeyHandler(w http.ResponseWriter, r *http.Request) {
 func GatewaySend(to string, message string, filename string) (bool, string) {
 	var errormessage string
 	var err error
-	isGroup := regexp.MustCompile(`^([a-fA-F\d]{32})$`).MatchString(to)
+	isGroup := regexp.MustCompile(`^([a-f\d]{64})$`).MatchString(to)
 	if filename != "" {
 		f, fErr := os.Open(filename)
 		if fErr != nil {


### PR DESCRIPTION
Fixed the Regex for Group Messaging. See https://github.com/signal-golang/textsecure/issues/45 and https://github.com/signal-golang/textsecure/issues/43