### PR TITLE
Fix: remove unimplemented crayfish ack

### DIFF
--- a/crayfish/backend.go
+++ b/crayfish/backend.go
@@ -263,31 +263,6 @@ func (c *Conn) connect(originURL string) error {
 	return nil
 }
 
-// Send ack response message
-func (c *Conn) sendAck() error {
-	typ := CrayfishWebSocketMessage_RESPONSE
-	message := ACKMessage{
-		Status: "ok",
-	}
-	responseType := CrayfishWebSocketResponseMessageTyp_ACK
-	csm := &CrayfishWebSocketMessage{
-		Type: &typ,
-		Response: &CrayfishWebSocketResponseMessage{
-			Type:    &responseType,
-			Message: &message,
-		},
-	}
-
-	b, err := json.Marshal(csm)
-	if err != nil {
-		return err
-	}
-	log.Debugln("[textsecure-crayfish-ws] websocket sending ack response ")
-
-	c.send <- b
-	return nil
-}
-
 // write writes a message with the given message type and payload.
 func (c *Conn) write(mt int, payload []byte) error {
 	Instance.cmd.Process.Signal(syscall.SIGCONT)
@@ -413,15 +388,6 @@ func (c *CrayfishInstance) StartWebsocket() error {
 
 		} else {
 			log.Errorln("[textsecure-crayfish-ws] failed to handle incoming websocket message")
-		}
-		if csm.Type != nil {
-			err = c.wsconn.sendAck()
-			if err != nil {
-				log.WithFields(log.Fields{
-					"error": err,
-				}).Error("[textsecure-crayfish-ws] Failed to send ack")
-				return err
-			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/signal-golang/textsecure/issues/57

As far as I can tell, ack is unimplemented on the crayfish side and ends up erroring with `{"error":"missing field 'request' at line 1 column 58"}`, since textsecure is sending a `response` instead.

The alternative is to handle the ack on the crayfish side [here](https://github.com/nanu-c/crayfish/blob/main/src/service/handlers.rs#L20-L24) by optionallly taking a `request|response` in the `RequestMessage<T>` struct and handling the message appropriately. Although I'm not sure what the intended action should be. Happy to do that instead with some guidance!