### PR TITLE
Upload attachment v3

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -245,13 +245,23 @@ func allocateAttachmentV3() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	log.Debug("[textsecure] allocateAttacmentV3 signedUploadLocation", signedUploadLocation)
-	resp, err := transport.CdnTransport.Post(signedUploadLocation, []byte{}, "application/octet-stream")
+	log.Debug("[textsecure] allocateAttacmentV3 signedUploadLocation ", signedUploadLocation)
+	req, err := http.NewRequest("POST", signedUploadLocation, nil)
 	if err != nil {
 		return "", err
 	}
-	if resp.IsError() {
+	req.Header.Add("Content-Type", "application/octet-stream")
+	req.Header.Add("Content-Length", "0")
+
+	client := transport.NewHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
 		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("HTTP status %d\n", resp.StatusCode)
 	}
 	return resp.Header.Get("Location"), nil
 }

--- a/attachments.go
+++ b/attachments.go
@@ -237,7 +237,7 @@ func fetchSignedUploadLocation() (string, error) {
 
 func relativeUrlPath(location string) string {
 	parts := strings.Split(location, "/")
-	return strings.Join(parts[3:], "/")
+	return "/" + strings.Join(parts[3:], "/")
 }
 
 func allocateAttachmentV3() (string, error) {

--- a/attachments.go
+++ b/attachments.go
@@ -126,7 +126,7 @@ func uploadAttachmentV3(r io.Reader, ct string, isVoiceNote bool) (*att, error) 
 	if err != nil {
 		return nil, err
 	}
-	log.Debug("[textsecure] uploadAttachmentV3 location", location)
+	log.Debug("[textsecure] uploadAttachmentV3 location ", location)
 	digest, err := putAttachment(location, m)
 	if err != nil {
 		return nil, err
@@ -250,7 +250,7 @@ func allocateAttachmentV3() (string, error) {
 		return "", err
 	}
 	if resp.IsError() {
-		return "", err
+		return "", resp
 	}
 	return resp.Header.Get("Location"), nil
 }

--- a/attachments.go
+++ b/attachments.go
@@ -39,21 +39,6 @@ func getAttachment(url string) (io.ReadCloser, error) {
 }
 
 // putAttachment uploads an encrypted attachment to the given URL
-func putAttachmentV3(url string, body []byte) ([]byte, error) {
-	resp, err := transport.CdnTransport.Put(url, body, "application/octet-stream")
-	if err != nil {
-		return nil, err
-	}
-	if resp.IsError() {
-		return nil, resp
-	}
-	hasher := sha256.New()
-	hasher.Write(body)
-
-	return hasher.Sum(nil), nil
-}
-
-// putAttachment uploads an encrypted attachment to the given URL
 func putAttachment(url string, body []byte) ([]byte, error) {
 	br := bytes.NewReader(body)
 	req, err := http.NewRequest("PUT", url, br)
@@ -142,7 +127,7 @@ func uploadAttachmentV3(r io.Reader, ct string, isVoiceNote bool) (*att, error) 
 		return nil, err
 	}
 	log.Debug("[textsecure] uploadAttachmentV3 location ", location)
-	digest, err := putAttachmentV3(location, m)
+	digest, err := putAttachment(location, m)
 	if err != nil {
 		return nil, err
 	}
@@ -260,15 +245,15 @@ func allocateAttachmentV3() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	/*resp, err := transport.CdnTransport.Post(signedUploadLocation, []byte{}, "application/octet-stream")
+	resp, err := transport.CdnTransport.Post(signedUploadLocation, []byte{}, "application/octet-stream")
 	if err != nil {
 		return "", err
 	}
 	if resp.IsError() {
+		log.Debug("[textsecure] allocateAttachmentV3 error response ", resp.Body)
 		return "", resp
 	}
-	return resp.Header.Get("Location"), nil*/
-	return signedUploadLocation, nil
+	return resp.Header.Get("Location"), nil
 }
 
 // GET /v1/attachments/

--- a/attachments.go
+++ b/attachments.go
@@ -39,6 +39,21 @@ func getAttachment(url string) (io.ReadCloser, error) {
 }
 
 // putAttachment uploads an encrypted attachment to the given URL
+func putAttachmentV3(url string, body []byte) ([]byte, error) {
+	resp, err := transport.CdnTransport.Put(url, body, "application/octet-stream")
+	if err != nil {
+		return nil, err
+	}
+	if resp.IsError() {
+		return nil, resp
+	}
+	hasher := sha256.New()
+	hasher.Write(body)
+
+	return hasher.Sum(nil), nil
+}
+
+// putAttachment uploads an encrypted attachment to the given URL
 func putAttachment(url string, body []byte) ([]byte, error) {
 	br := bytes.NewReader(body)
 	req, err := http.NewRequest("PUT", url, br)
@@ -127,7 +142,7 @@ func uploadAttachmentV3(r io.Reader, ct string, isVoiceNote bool) (*att, error) 
 		return nil, err
 	}
 	log.Debug("[textsecure] uploadAttachmentV3 location ", location)
-	digest, err := putAttachment(location, m)
+	digest, err := putAttachmentV3(location, m)
 	if err != nil {
 		return nil, err
 	}
@@ -245,14 +260,15 @@ func allocateAttachmentV3() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp, err := transport.CdnTransport.Post(signedUploadLocation, []byte{}, "application/octet-stream")
+	/*resp, err := transport.CdnTransport.Post(signedUploadLocation, []byte{}, "application/octet-stream")
 	if err != nil {
 		return "", err
 	}
 	if resp.IsError() {
 		return "", resp
 	}
-	return resp.Header.Get("Location"), nil
+	return resp.Header.Get("Location"), nil*/
+	return signedUploadLocation, nil
 }
 
 // GET /v1/attachments/

--- a/attachments.go
+++ b/attachments.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 
 	signalservice "github.com/signal-golang/textsecure/protobuf"
 	textsecure "github.com/signal-golang/textsecure/protobuf"
@@ -232,12 +231,7 @@ func fetchSignedUploadLocation() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return relativeUrlPath(a.SignedUploadLocation), nil
-}
-
-func relativeUrlPath(location string) string {
-	parts := strings.Split(location, "/")
-	return strings.Join(parts[2:], "/")
+	return a.SignedUploadLocation, nil
 }
 
 func allocateAttachmentV3() (string, error) {
@@ -245,7 +239,6 @@ func allocateAttachmentV3() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	log.Debug("[textsecure] allocateAttacmentV3 signedUploadLocation ", signedUploadLocation)
 	req, err := http.NewRequest("POST", signedUploadLocation, nil)
 	if err != nil {
 		return "", err

--- a/groups.go
+++ b/groups.go
@@ -202,7 +202,7 @@ func GetContactForTel(tel string) *contacts.Contact {
 	}
 	return nil
 }
-func sendGroupV2Helper(hexid string, msg string, a *att, timer uint32) (uint64, error) {
+func sendGroupV2Helper(hexid string, msg string, attachmentPointer *attachmentPointerV3, timer uint32) (uint64, error) {
 	var ts uint64
 	var err error
 	g := groupsV2.FindGroup(hexid)
@@ -232,7 +232,7 @@ func sendGroupV2Helper(hexid string, msg string, a *att, timer uint32) (uint64, 
 		omsg := &outgoingMessage{
 			destination: idToHexUUID(m.Uuid),
 			msg:         msg,
-			attachment:  a,
+			attachment:  attachmentPointer,
 			expireTimer: timer,
 			timestamp:   &timestamp,
 			groupV2:     groupsV2Context,
@@ -247,13 +247,13 @@ func sendGroupV2Helper(hexid string, msg string, a *att, timer uint32) (uint64, 
 	return ts, nil
 }
 
-func sendGroupHelper(hexid string, msg string, a *att, timer uint32) (uint64, error) {
+func sendGroupHelper(hexid string, msg string, attachmentPointer *attachmentPointerV3, timer uint32) (uint64, error) {
 	var ts uint64
 	var err error
 	g, ok := groups[hexid]
 	if !ok {
 		log.Infoln("[textsecure] sendGroupHelper unknown group id")
-		ts, err = sendGroupV2Helper(hexid, msg, a, timer)
+		ts, err = sendGroupV2Helper(hexid, msg, attachmentPointer, timer)
 		if err != nil {
 			return 0, UnknownGroupIDError{hexid}
 		}
@@ -281,7 +281,7 @@ func sendGroupHelper(hexid string, msg string, a *att, timer uint32) (uint64, er
 			omsg := &outgoingMessage{
 				destination: m,
 				msg:         msg,
-				attachment:  a,
+				attachment:  attachmentPointer,
 				expireTimer: timer,
 				timestamp:   &timestamp,
 				group: &groupMessage{
@@ -309,21 +309,21 @@ func SendGroupMessage(hexid string, msg string, timer uint32) (uint64, error) {
 // SendGroupAttachment sends an attachment to a given group.
 func SendGroupAttachment(hexid string, msg string, r io.Reader, timer uint32) (uint64, error) {
 	ct, r := MIMETypeFromReader(r)
-	a, err := uploadAttachment(r, ct)
+	attachmentPointer, err := uploadAttachment(r, ct)
 	if err != nil {
 		return 0, err
 	}
-	return sendGroupHelper(hexid, msg, a, timer)
+	return sendGroupHelper(hexid, msg, attachmentPointer, timer)
 }
 
 // SendGroupVoiceNote sends an voice note to a group
 func SendGroupVoiceNote(hexid string, msg string, r io.Reader, timer uint32) (uint64, error) {
 	ct, r := MIMETypeFromReader(r)
-	a, err := uploadVoiceNote(r, ct)
+	attachmentPointer, err := uploadVoiceNote(r, ct)
 	if err != nil {
 		return 0, err
 	}
-	return sendGroupHelper(hexid, msg, a, timer)
+	return sendGroupHelper(hexid, msg, attachmentPointer, timer)
 }
 func newGroupID() []byte {
 	id := make([]byte, 16)

--- a/groupsv2/groupsv2.go
+++ b/groupsv2/groupsv2.go
@@ -229,7 +229,10 @@ func GetGroupV2MembersForGroup(group string) ([]*signalservice.DecryptedMember, 
 	if g == nil {
 		return nil, fmt.Errorf("Group not found")
 	}
-	g.UpdateGroupFromServer()
+	err := g.UpdateGroupFromServer()
+	if err != nil {
+		log.Debugln("[textsecure] could not update group from server")
+	}
 
 	return g.DecryptedGroup.Members, nil
 }

--- a/server.go
+++ b/server.go
@@ -721,7 +721,7 @@ func GetRegisteredContacts() ([]contacts.Contact, error) {
 
 // Attachment handling
 type attachmentV3UploadAttributes struct {
-	SignedUploadLocation string "json: signedUploadLocation"
+	SignedUploadLocation string `json:"signedUploadLocation"`
 }
 
 type jsonAllocation struct {

--- a/server.go
+++ b/server.go
@@ -721,7 +721,15 @@ func GetRegisteredContacts() ([]contacts.Contact, error) {
 
 // Attachment handling
 type attachmentV3UploadAttributes struct {
-	SignedUploadLocation string `json:"signedUploadLocation"`
+	Cdn                  string            `json:"cdn"`
+	Key                  string            `json:"key"`
+	Headers              map[string]string `json:"headers"`
+	SignedUploadLocation string            `json:"signedUploadLocation"`
+}
+
+func (a *attachmentV3UploadAttributes) relativeSignedUploadLocation() string {
+	parts := strings.Split(a.SignedUploadLocation, "/")
+	return "/" + strings.Join(parts[3:], "/")
 }
 
 type jsonAllocation struct {

--- a/server.go
+++ b/server.go
@@ -721,7 +721,7 @@ func GetRegisteredContacts() ([]contacts.Contact, error) {
 
 // Attachment handling
 type attachmentV3UploadAttributes struct {
-	Cdn                  string            `json:"cdn"`
+	Cdn                  int               `json:"cdn"`
 	Key                  string            `json:"key"`
 	Headers              map[string]string `json:"headers"`
 	SignedUploadLocation string            `json:"signedUploadLocation"`

--- a/server.go
+++ b/server.go
@@ -57,7 +57,6 @@ var (
 	DELETE_USERNAME_PATH      = "/v1/accounts/username"
 	DELETE_ACCOUNT_PATH       = "/v1/accounts/me"
 
-	allocateAttachmentPath   = "/v1/attachments/"
 	attachmentPath           = "/v2/attachments/form/upload"
 	ATTACHMENT_DOWNLOAD_PATH = "/v2/attachments/"
 

--- a/server.go
+++ b/server.go
@@ -721,7 +721,7 @@ func GetRegisteredContacts() ([]contacts.Contact, error) {
 
 // Attachment handling
 type attachmentV3UploadAttributes struct {
-	Cdn                  int               `json:"cdn"`
+	Cdn                  uint32            `json:"cdn"`
 	Key                  string            `json:"key"`
 	Headers              map[string]string `json:"headers"`
 	SignedUploadLocation string            `json:"signedUploadLocation"`
@@ -760,8 +760,8 @@ func createMessage(msg *outgoingMessage) *signalservice.DataMessage {
 	}
 	dm.ExpireTimer = &msg.expireTimer
 	if msg.attachment != nil {
-		id := signalservice.AttachmentPointer_CdnId{
-			CdnId: msg.attachment.id,
+		id := signalservice.AttachmentPointer_CdnKey{
+			CdnKey: msg.attachment.cdnKey,
 		}
 		// todo send file names
 		filename := ""
@@ -771,6 +771,7 @@ func createMessage(msg *outgoingMessage) *signalservice.DataMessage {
 		dm.Attachments = []*signalservice.AttachmentPointer{
 			{
 				AttachmentIdentifier: &id,
+				CdnNumber:            &msg.attachment.cdnNr,
 				ContentType:          &msg.attachment.ct,
 				Key:                  msg.attachment.keys[:],
 				Digest:               msg.attachment.digest[:],

--- a/server.go
+++ b/server.go
@@ -727,11 +727,6 @@ type attachmentV3UploadAttributes struct {
 	SignedUploadLocation string            `json:"signedUploadLocation"`
 }
 
-func (a *attachmentV3UploadAttributes) relativeSignedUploadLocation() string {
-	parts := strings.Split(a.SignedUploadLocation, "/")
-	return "/" + strings.Join(parts[3:], "/")
-}
-
 type jsonAllocation struct {
 	ID       uint64 `json:"id"`
 	Location string `json:"location"`

--- a/server.go
+++ b/server.go
@@ -36,6 +36,7 @@ import (
 
 var (
 	SERVICE_REFLECTOR_HOST = "europe-west1-signal-cdn-reflector.cloudfunctions.net"
+	SIGNAL_SERVICE_URL     = "https://chat.signal.org"
 	SIGNAL_CDN_URL         = "https://cdn.signal.org"
 	SIGNAL_CDN2_URL        = "https://cdn2.signal.org"
 	DIRECTORY_URL          = "https://api.directory.signal.org"
@@ -719,6 +720,9 @@ func GetRegisteredContacts() ([]contacts.Contact, error) {
 }
 
 // Attachment handling
+type attachmentV3UploadAttributes struct {
+	SignedUploadLocation string "json: signedUploadLocation"
+}
 
 type jsonAllocation struct {
 	ID       uint64 `json:"id"`

--- a/sync.go
+++ b/sync.go
@@ -186,7 +186,7 @@ func sendContactUpdate() error {
 
 	}
 
-	a, err := uploadAttachment(&buf, "application/octet-stream")
+	attachmentPointer, err := uploadAttachment(&buf, "application/octet-stream")
 	if err != nil {
 		return err
 	}
@@ -194,13 +194,14 @@ func sendContactUpdate() error {
 	sm := &signalservice.SyncMessage{
 		Contacts: &signalservice.SyncMessage_Contacts{
 			Blob: &signalservice.AttachmentPointer{
-				AttachmentIdentifier: &signalservice.AttachmentPointer_CdnId{
-					CdnId: a.id,
+				AttachmentIdentifier: &signalservice.AttachmentPointer_CdnKey{
+					CdnKey: attachmentPointer.cdnKey,
 				},
-				ContentType: &a.ct,
-				Key:         a.keys[:],
-				Digest:      a.digest[:],
-				Size:        &a.size,
+				CdnNumber:   &attachmentPointer.cdnNr,
+				ContentType: &attachmentPointer.ct,
+				Key:         attachmentPointer.keys[:],
+				Digest:      attachmentPointer.digest[:],
+				Size:        &attachmentPointer.size,
 			},
 		},
 	}
@@ -233,7 +234,7 @@ func sendGroupUpdate() error {
 		buf.Write(b)
 	}
 
-	a, err := uploadAttachment(&buf, "application/octet-stream")
+	attachmentPointer, err := uploadAttachment(&buf, "application/octet-stream")
 	if err != nil {
 		return err
 	}
@@ -241,13 +242,14 @@ func sendGroupUpdate() error {
 	sm := &signalservice.SyncMessage{
 		Groups: &signalservice.SyncMessage_Groups{
 			Blob: &signalservice.AttachmentPointer{
-				AttachmentIdentifier: &signalservice.AttachmentPointer_CdnId{
-					CdnId: a.id,
+				AttachmentIdentifier: &signalservice.AttachmentPointer_CdnKey{
+					CdnKey: attachmentPointer.cdnKey,
 				},
-				ContentType: &a.ct,
-				Key:         a.keys[:],
-				Digest:      a.digest[:],
-				Size:        &a.size,
+				CdnNumber:   &attachmentPointer.cdnNr,
+				ContentType: &attachmentPointer.ct,
+				Key:         attachmentPointer.keys[:],
+				Digest:      attachmentPointer.digest[:],
+				Size:        &attachmentPointer.size,
 			},
 		},
 	}

--- a/textsecure.go
+++ b/textsecure.go
@@ -314,7 +314,7 @@ func Setup(c *Client) error {
 	client.RegistrationDone()
 	rootCa.SetupCA(config.ConfigFile.RootCA)
 	transport.SetupTransporter(config.ConfigFile.Server, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)
-	transport.SetupCDNTransporter(SIGNAL_CDN_URL, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)
+	transport.SetupCDNTransporter(SIGNAL_CDN2_URL, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)
 	transport.SetupDirectoryTransporter(DIRECTORY_URL, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)
 	transport.SetupStorageTransporter(STORAGE_URL, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)
 	transport.SetupServiceTransporter(SIGNAL_SERVICE_URL, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)

--- a/textsecure.go
+++ b/textsecure.go
@@ -461,7 +461,7 @@ func registerDevice() error {
 
 func handleReceipt(env *signalservice.Envelope) {
 	if client.ReceiptHandler != nil {
-		client.ReceiptHandler(env.GetSourceUuid(), env.GetSourceDevice(), env.GetServerTimestamp())
+		client.ReceiptHandler(env.GetSourceUuid(), env.GetSourceDevice(), env.GetTimestamp())
 	}
 }
 

--- a/textsecure.go
+++ b/textsecure.go
@@ -317,6 +317,7 @@ func Setup(c *Client) error {
 	transport.SetupCDNTransporter(SIGNAL_CDN_URL, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)
 	transport.SetupDirectoryTransporter(DIRECTORY_URL, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)
 	transport.SetupStorageTransporter(STORAGE_URL, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)
+	transport.SetupServiceTransporter(SIGNAL_SERVICE_URL, config.ConfigFile.UUID, registration.Registration.Password, config.ConfigFile.UserAgent, config.ConfigFile.ProxyServer)
 	identityKey, err = textSecureStore.GetIdentityKeyPair()
 	// check if we have a uuid and if not get it
 	// config.ConfigFile = checkUUID(config.ConfigFile)

--- a/textsecure.go
+++ b/textsecure.go
@@ -90,15 +90,6 @@ func needsRegistration() bool {
 
 var identityKey *axolotl.IdentityKeyPair
 
-type att struct {
-	id        uint64
-	ct        string
-	keys      []byte
-	digest    []byte
-	size      uint32
-	voiceNote bool
-}
-
 type attachmentPointerV3 struct {
 	cdnKey    string
 	cdnNr     uint32

--- a/textsecure.go
+++ b/textsecure.go
@@ -99,12 +99,22 @@ type att struct {
 	voiceNote bool
 }
 
+type attachmentPointerV3 struct {
+	cdnKey    string
+	cdnNr     uint32
+	ct        string
+	keys      []byte
+	digest    []byte
+	size      uint32
+	voiceNote bool
+}
+
 type outgoingMessage struct {
 	destination string
 	msg         string
 	group       *groupMessage
 	groupV2     *signalservice.GroupContextV2
-	attachment  *att
+	attachment  *attachmentPointerV3
 	flags       uint32
 	expireTimer uint32
 	timestamp   *uint64

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/signal-golang/textsecure/helpers"
@@ -49,10 +50,17 @@ func SetupStorageTransporter(Url string, uuid string, password string, userAgent
 	StorageTransport = newHTTPTransporter(Url, uuid, password, userAgent, proxyServer, rootCa.DirectoryCA)
 }
 
+var ServiceTransport *httpTransporter
+
+func SetupServiceTransporter(Url string, uuid string, password string, userAgent string, proxyServer string) {
+	ServiceTransport = newHTTPTransporter(Url, uuid, password, userAgent, proxyServer, rootCa.DirectoryCA)
+}
+
 type response struct {
 	Status  int
 	Body    io.ReadCloser
 	Cookies string
+	Header  *http.Header
 }
 
 func (r *response) IsError() bool {
@@ -67,6 +75,7 @@ type Transporter interface {
 	Get(url string) (*response, error)
 	Del(url string) (*response, error)
 	Put(url string, body []byte, ct string) (*response, error)
+	Post(url string, body []byte, contentType string) (*response, error)
 	PutWithAuth(url string, body []byte, ct string, auth string) (*response, error)
 	PatchWithAuth(url string, body []byte, ct string, auth string) (*response, error)
 
@@ -188,6 +197,34 @@ func (ht *httpTransporter) Del(url string) (*response, error) {
 	}
 
 	log.Debugf("DELETE %s %d\n", url, r.Status)
+
+	return r, err
+}
+
+func (ht *httpTransporter) Post(url string, body []byte, ct string) (*response, error) {
+	br := bytes.NewReader(body)
+	req, err := http.NewRequest("POST", ht.baseURL+url, br)
+	if err != nil {
+		return nil, err
+	}
+	if ht.userAgent != "" {
+		req.Header.Set("X-Signal-Agent", ht.userAgent)
+	}
+	req.Header.Add("Content-Type", ct)
+	req.Header.Add("Content-Length", strconv.Itoa(len(body)))
+	req.SetBasicAuth(ht.user, ht.pass)
+	resp, err := ht.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	r := &response{}
+	if resp != nil {
+		r.Status = resp.StatusCode
+		r.Body = resp.Body
+		r.Header = &resp.Header
+	}
+
+	log.Debugf("[textsecure] POST %s %d\n", url, r.Status)
 
 	return r, err
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -75,7 +75,7 @@ type Transporter interface {
 	Get(url string) (*response, error)
 	Del(url string) (*response, error)
 	Put(url string, body []byte, ct string) (*response, error)
-	Post(url string, body []byte, contentType string) (*response, error)
+	PostWithHeaders(url string, body []byte, contentType string, headers map[string]string) (*response, error)
 	PutWithAuth(url string, body []byte, ct string, auth string) (*response, error)
 	PatchWithAuth(url string, body []byte, ct string, auth string) (*response, error)
 
@@ -201,11 +201,14 @@ func (ht *httpTransporter) Del(url string) (*response, error) {
 	return r, err
 }
 
-func (ht *httpTransporter) Post(url string, body []byte, ct string) (*response, error) {
+func (ht *httpTransporter) PostWithHeaders(url string, body []byte, ct string, headers map[string]string) (*response, error) {
 	br := bytes.NewReader(body)
 	req, err := http.NewRequest("POST", ht.baseURL+url, br)
 	if err != nil {
 		return nil, err
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
 	}
 	if ht.userAgent != "" {
 		req.Header.Set("X-Signal-Agent", ht.userAgent)


### PR DESCRIPTION
I tried to implement upload attachment v3 without being resumable. Maybe that's what v2 is. :shrug: 

Its now a three step process.
1. fetch attributes for attachment upload [getAttachmentV3UploadAttributes()](https://github.com/signalapp/Signal-Android/blob/1fe4c45c44b6a6ce84c4c56f89c75b923b50ce46/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java#L1255)
1.1. The signed upload location (that is some location on cdn2.signal.org with credentials encoded into the url)
1.2 A map of headers needed for that call
1.3 Some other unneeded infos
2. make an empty post on that location with those headers, retrieve "location" from the response header [getResumableUploadUrl()](https://github.com/signalapp/Signal-Android/blob/1fe4c45c44b6a6ce84c4c56f89c75b923b50ce46/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java#L1465)
3. put the attachment on the retrieved location [uploadToCdn2()](https://github.com/signalapp/Signal-Android/blob/07915db7bc5720e8de8fee3a8683b1bb1686e436/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java#L1478)

All three steps are working.

Additionally the type of the remoteId (formally known as CdnId) was changed from Long to String. Its now called CdnKey.

I could successfully send a voice message. :partying_face: 